### PR TITLE
bug/MOB-5329: iOS: No outbound call ringing sound when placing a call from native call history on iPhone (CS3)

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -11,6 +11,7 @@ const RNCallKeepDidDeactivateAudioSession = 'RNCallKeepDidDeactivateAudioSession
 const RNCallKeepDidDisplayIncomingCall = 'RNCallKeepDidDisplayIncomingCall';
 const RNCallKeepDidPerformSetMutedCallAction = 'RNCallKeepDidPerformSetMutedCallAction';
 const RNCallKeepDidToggleHoldAction = 'RNCallKeepDidToggleHoldAction';
+const RNCallKeepPerformGroupCallAction = 'RNCallKeepPerformGroupCallAction';
 const RNCallKeepDidPerformDTMFAction = 'RNCallKeepDidPerformDTMFAction';
 const RNCallKeepProviderReset = 'RNCallKeepProviderReset';
 const RNCallKeepCheckReachability = 'RNCallKeepCheckReachability';
@@ -63,6 +64,9 @@ const didPerformSetMutedCallAction = handler =>
 const didToggleHoldCallAction = handler =>
   eventEmitter.addListener(RNCallKeepDidToggleHoldAction, handler);
 
+const performGroupCallAction = handler =>
+  eventEmitter.addListener(RNCallKeepPerformGroupCallAction, handler);
+
 const didPerformDTMFAction = handler =>
   eventEmitter.addListener(RNCallKeepDidPerformDTMFAction, (data) => handler(data));
 
@@ -95,6 +99,7 @@ export const listeners = {
   didDisplayIncomingCall,
   didPerformSetMutedCallAction,
   didToggleHoldCallAction,
+  performGroupCallAction,
   didPerformDTMFAction,
   didResetProvider,
   checkReachability,

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,4 +32,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
+    implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.1.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,4 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.1.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,5 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:0.66.3'
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -203,5 +203,9 @@ declare module 'react-native-callkeep' {
     static setCurrentCallActive(callUUID: string): void
 
     static backToForeground(): void
+
+    static configureVoiceAudioSession(): void
+
+    static configureVideoAudioSession(): void
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -178,6 +178,7 @@ declare module 'react-native-callkeep' {
     static setOnHold(uuid: string, held: boolean): void
     
     static setGroupCall(activeUuid: string, heldUuid: string): void
+    static setGroupCallFulfilled(): void
 
     static setConnectionState(uuid: string, state: number): void
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ declare module 'react-native-callkeep' {
     'didDeactivateAudioSession' |
     'didDisplayIncomingCall' |
     'didToggleHoldCallAction' |
+    'performGroupCallAction' |
     'didPerformDTMFAction' |
     'didResetProvider' |
     'checkReachability' |
@@ -175,6 +176,8 @@ declare module 'react-native-callkeep' {
     static toggleAudioRouteSpeaker(uuid: string, routeSpeaker: boolean): void
 
     static setOnHold(uuid: string, held: boolean): void
+    
+    static setGroupCall(activeUuid: string, heldUuid: string): void
 
     static setConnectionState(uuid: string, state: number): void
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,6 +145,8 @@ declare module 'react-native-callkeep' {
      */
     static isCallActive(uuid: string): Promise<boolean>
 
+    static isAudioSessionActive(): Promise<boolean>
+
     static getCalls(): Promise<object>
 
     static getAudioRoutes(): Promise<void>

--- a/index.js
+++ b/index.js
@@ -260,6 +260,7 @@ class RNCallKeep {
   setOnHold = (uuid, shouldHold) => RNCallKeepModule.setOnHold(uuid, shouldHold);
   
   setGroupCall = (activeUuid, heldUuid) => RNCallKeepModule.setGroupCall(activeUuid, heldUuid);
+  setGroupCallFulfilled = () => RNCallKeepModule.setGroupCallFulfilled();
 
   setConnectionState = (uuid, state) => isIOS ? null : RNCallKeepModule.setConnectionState(uuid, state);
 

--- a/index.js
+++ b/index.js
@@ -258,6 +258,8 @@ class RNCallKeep {
   };
 
   setOnHold = (uuid, shouldHold) => RNCallKeepModule.setOnHold(uuid, shouldHold);
+  
+  setGroupCall = (activeUuid, heldUuid) => RNCallKeepModule.setGroupCall(activeUuid, heldUuid);
 
   setConnectionState = (uuid, state) => isIOS ? null : RNCallKeepModule.setConnectionState(uuid, state);
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,17 @@ class RNCallKeep {
   addEventListener = (type, handler) => {
     const listener = listeners[type](handler);
 
+    /**
+     * xxx https://idtjira.atlassian.net/browse/MOB-5329
+     */
+    if (type === 'didActivateAudioSession') {
+      this.isAudioSessionActive().then(isActive => {
+        if (isActive) {
+          handler()
+        }
+      })
+    }
+
     this._callkeepEventHandlers.set(type, listener);
   };
 
@@ -169,6 +180,8 @@ class RNCallKeep {
   };
 
   isCallActive = async (uuid) => await RNCallKeepModule.isCallActive(uuid);
+
+  isAudioSessionActive = RNCallKeepModule.isAudioSessionActive;
 
   getCalls = () => {
     if (isIOS) {

--- a/index.js
+++ b/index.js
@@ -350,6 +350,14 @@ class RNCallKeep {
   clearInitialEvents() {
     return RNCallKeepModule.clearInitialEvents();
   }
+
+  configureVideoAudioSession() {
+    return RNCallKeepModule.configureVideoAudioSession();
+  }
+
+  configureVoiceAudioSession() {
+    return RNCallKeepModule.configureVoiceAudioSession();
+  }
 }
 
 export default new RNCallKeep();

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -45,6 +45,7 @@ continueUserActivity:(NSUserActivity *)userActivity
                  reason:(int)reason;
 
 + (BOOL)isCallActive:(NSString *)uuidString;
++ (BOOL)isAudioSessionActive;
 
 + (void)setup:(NSDictionary *)options;
 

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -48,4 +48,7 @@ continueUserActivity:(NSUserActivity *)userActivity
 
 + (void)setup:(NSDictionary *)options;
 
++ (void)configureVoiceAudioSession;
++ (void)configureVideoAudioSession;
+
 @end

--- a/ios/RNCallKeep/RNCallKeep.h
+++ b/ios/RNCallKeep/RNCallKeep.h
@@ -18,6 +18,7 @@
 
 @property (nonatomic, strong) CXCallController *callKeepCallController;
 @property (nonatomic, strong) CXProvider *callKeepProvider;
+@property (nonatomic, strong) CXSetGroupCallAction * callKeepGroupCallAction;
 
 + (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -403,6 +403,16 @@ RCT_EXPORT_METHOD(setGroupCall:(NSString *)activeUuidString :(NSString *)heldUui
     [self requestTransaction:transaction];
 }
 
+RCT_EXPORT_METHOD(setGroupCallFulfilled)
+{
+#ifdef DEBUG
+    NSLog(@"[RNCallKeep][setGroupCallFulfilled]");
+#endif
+    if (self.callKeepGroupCallAction != nil) {
+        [self.callKeepGroupCallAction fulfill];
+    }
+}
+
 RCT_EXPORT_METHOD(_startCallActionEventListenerAdded)
 {
     _isStartCallActionEventListenerAdded = YES;
@@ -1075,7 +1085,8 @@ RCT_EXPORT_METHOD(reportUpdatedCall:(NSString *)uuidString contactIdentifier:(NS
 #endif
 
     [self sendEventWithNameWrapper:RNCallKeepPerformGroupCallAction body:@{ @"activeCallUUID": [action.callUUID.UUIDString lowercaseString], @"heldCallUUID": [action.callUUIDToGroupWith.UUIDString lowercaseString] }];
-    [action fulfill];
+    
+    self.callKeepGroupCallAction = action;
 }
 
 - (void)provider:(CXProvider *)provider performPlayDTMFCallAction:(CXPlayDTMFCallAction *)action {

--- a/ios/RNCallKeep/RNCallKeep.m
+++ b/ios/RNCallKeep/RNCallKeep.m
@@ -44,6 +44,7 @@ static NSString *const RNCallKeepDidLoadWithEvents = @"RNCallKeepDidLoadWithEven
     NSOperatingSystemVersion _version;
     BOOL _isStartCallActionEventListenerAdded;
     bool _hasListeners;
+    bool _isAudioSessionActive;
     bool _isReachable;
     NSMutableArray *_delayedEvents;
 }
@@ -163,6 +164,13 @@ RCT_EXPORT_MODULE()
             nil
         ];
         [_delayedEvents addObject:dictionary];
+        
+    }
+    
+    if ([name isEqualToString:@"RNCallKeepDidReceiveStartCallAction"]) {
+        [_delayedEvents addObject: [NSDictionary dictionaryWithObjectsAndKeys:
+                                    @"RNCallKeepDidActivateAudioSession", @"name", nil]];
+        _isAudioSessionActive = YES;
     }
 }
 
@@ -360,7 +368,7 @@ RCT_EXPORT_METHOD(endCall:(NSString *)uuidString)
     NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
     CXEndCallAction *endCallAction = [[CXEndCallAction alloc] initWithCallUUID:uuid];
     CXTransaction *transaction = [[CXTransaction alloc] initWithAction:endCallAction];
-
+    _isAudioSessionActive = NO;
     [self requestTransaction:transaction];
 }
 
@@ -372,6 +380,7 @@ RCT_EXPORT_METHOD(endAllCalls)
     for (CXCall *call in self.callKeepCallController.callObserver.calls) {
         CXEndCallAction *endCallAction = [[CXEndCallAction alloc] initWithCallUUID:call.UUID];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:endCallAction];
+        _isAudioSessionActive = NO;
         [self requestTransaction:transaction];
     }
 }
@@ -489,6 +498,12 @@ RCT_EXPORT_METHOD(sendDTMF:(NSString *)uuidString dtmf:(NSString *)key)
     [transaction addAction:dtmfAction];
 
     [self requestTransaction:transaction];
+}
+
+RCT_EXPORT_METHOD(isAudioSessionActive:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    resolve([NSNumber numberWithBool:_isAudioSessionActive]);
 }
 
 RCT_EXPORT_METHOD(isCallActive:(NSString *)uuidString
@@ -999,6 +1014,7 @@ continueUserActivity:(NSUserActivity *)userActivity
         };
 
         RNCallKeep *callKeep = [RNCallKeep allocWithZone: nil];
+
         [callKeep sendEventWithNameWrapper:RNCallKeepDidReceiveStartCallAction body:userInfo];
         return YES;
     }
@@ -1076,6 +1092,7 @@ RCT_EXPORT_METHOD(configureVideoAudioSession)
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][CXProviderDelegate][provider:performEndCallAction]");
 #endif
+    _isAudioSessionActive = NO;
     [self sendEventWithNameWrapper:RNCallKeepPerformEndCallAction body:@{ @"callUUID": [action.callUUID.UUIDString lowercaseString] }];
     [action fulfill];
 }
@@ -1139,6 +1156,8 @@ RCT_EXPORT_METHOD(configureVideoAudioSession)
     [[NSNotificationCenter defaultCenter] postNotificationName:AVAudioSessionInterruptionNotification object:nil userInfo:userInfo];
 
     //[self configureAudioSession];
+    _isAudioSessionActive = YES;
+
     [self sendEventWithNameWrapper:RNCallKeepDidActivateAudioSession body:nil];
 }
 
@@ -1147,6 +1166,7 @@ RCT_EXPORT_METHOD(configureVideoAudioSession)
 #ifdef DEBUG
     NSLog(@"[RNCallKeep][CXProviderDelegate][provider:didDeactivateAudioSession]");
 #endif
+    _isAudioSessionActive = NO;
     [self sendEventWithNameWrapper:RNCallKeepDidDeactivateAudioSession body:nil];
 }
 


### PR DESCRIPTION
This PR adds a new property to RNCallKeep native module called `_isAudioSessionActive` which is used to keep track of the Audio Session.

On The JS side, we check if the AudioSession is activated when setting the event listener. If the Audio Session was activated before the event listener, we immediately fire the event handler.